### PR TITLE
Dev ollama

### DIFF
--- a/publish.yaml
+++ b/publish.yaml
@@ -11,7 +11,7 @@ Type: Application
 Name: start-modelscope
 Provider:
   - 阿里云 
-Version: 0.2.14
+Version: dev
 Description: ModelScope应用
 HomePage: https://github.com/devsapp/start-modelscope
 Tags:

--- a/publish.yaml
+++ b/publish.yaml
@@ -33,6 +33,7 @@ Parameters:
   additionalProperties: false
   required: # 必填项
     - region
+    - imageTag
     - serviceName
     - roleArn
     - modelId
@@ -41,6 +42,10 @@ Parameters:
     - gpuMemorySize
     - memorySize
     - modelCache
+    - ggufFile
+    - modelfile
+    - modelFamily
+    - servedModelName
   properties:
     region:
       title: 地域
@@ -51,6 +56,11 @@ Parameters:
         # - cn-beijing
         - cn-hangzhou
         - cn-shanghai
+    imageTag:
+      title: modelscope镜像tag
+      type: string
+      default: fc-deploy-common-v17.3.3
+      description: registry.${vars.region}.aliyuncs.com/modelscope-repo/modelscope镜像的tag版本。24年7月以后，与modelscope镜像统一
     serviceName:
       title: 服务名
       type: string
@@ -121,3 +131,23 @@ Parameters:
         - "www.modelscope.cn"
         - "modelsce-mirror-modelsce-mirror-txpzbgwcck.cn-hangzhou-vpc.fcapp.run"
         - "modelsce-mirror-modelsce-mirror-txpzbgwcck.cn-shanghai-vpc.fcapp.run"
+    ggufFile:
+      title: gguf文件
+      type: string
+      default: ""
+      description: gguf格式的模型文件，使用ollama启动时为必须参数
+    modelfile:
+      title: ollama模型template文件内容
+      type: string
+      default: ""
+      description: ollama创建模型时所需的模型template文件的内容, 不配置时将以modelFamily取该类模型的默认配置
+    modelFamily:
+      title: 模型family
+      type: string
+      default: ""
+      description: 模型的类型，如qwen2, 用以获取ollama创建模型时所需的模型默认template文件
+    servedModelName:
+      title: 模型服务名
+      type: string
+      pattern: "^[a-zA-Z_][a-zA-Z0-9-_]{0,127}$"
+      description: 用户可配置的部署后模型名称，只能包含字母、数字、下划线和中划线。不能以数字、中划线开头。长度在 1-128 之间

--- a/src/model_deploy/index.py
+++ b/src/model_deploy/index.py
@@ -13,4 +13,22 @@ def handler(event, context):
     family = os.getenv('MODEL_FAMILY', '')
     served_model_name = os.getenv('SERVED_MODEL_NAME', '')
 
-    return {'served_model_name': served_model_name}
+    cmd = f'cd {cache_dir}/ollama-linux && sudo chmod 777 ./ollama-modelscope-install.sh && ./ollama-modelscope-install.sh'
+    os.system(cmd)
+    cmd = 'ollama serve &'
+    os.system(cmd)
+
+    if modelfile and len(modelfile):
+        os.system(f'cat {modelfile} > {cache_dir}/ModelFile')
+    elif family and len(family):
+        os.system(f'wget https://modelscope.oss-cn-beijing.aliyuncs.com/llm_template/ollama/{family}.modelfile')
+        command_gen_modelfile = f'cat {family}.modelfile | sed "s/' + '{gguf_file}' + f'/{gguf_file}/" > ./ModelFile'
+        os.system(command_gen_modelfile)
+    else:
+        raise ValueError(f'modelfile 和 model_family至少需要配置一个。用于ollama模型初始化。')
+    
+    # run ollama
+    cmd = f'ollama create {served_model_name} --file ./ModelFile'
+    os.system(cmd)
+    cmd = f'ollama run {served_model_name}'
+    os.system(cmd)

--- a/src/model_deploy/index.py
+++ b/src/model_deploy/index.py
@@ -1,0 +1,16 @@
+import os 
+from modelscope.hub.api import HubApi
+from modelscope.hub.snapshot_download import snapshot_download
+
+def handler(event, context):
+    model_id = os.getenv('MODEL_ID', '')
+    revision = os.getenv('MODEL_VERSION', '')
+    cache_dir = os.getenv('MODELSCOPE_CACHE', '')
+    sdk_token = os.getenv('MODELSCOPE_TOKEN', '')
+    image_tag = os.getenv('IMAGE_TAG', '')
+    gguf_file = os.getenv('GGUF_FILE', '')
+    modelfile = os.getenv('MODELFILE', '')
+    family = os.getenv('MODEL_FAMILY', '')
+    served_model_name = os.getenv('SERVED_MODEL_NAME', '')
+
+    return {'served_model_name': served_model_name}

--- a/src/model_download/index.py
+++ b/src/model_download/index.py
@@ -9,8 +9,6 @@ def handler(event, context):
     sdk_token = os.getenv('MODELSCOPE_TOKEN', '')
     image_tag = os.getenv('IMAGE_TAG', '')
     gguf_file = os.getenv('GGUF_FILE', '')
-    modelfile = os.getenv('MODELFILE', '')
-    family = os.getenv('MODEL_FAMILY', '')
 
     # login first.
     HubApi().login(sdk_token)
@@ -29,14 +27,5 @@ def handler(event, context):
 
         command_download_model = f'modelscope download --model={model_id} --local_dir {cache_dir} ${gguf_file}'
         os.system(command_download_model)
-
-        if modelfile and len(modelfile):
-            os.system(f'cat {modelfile} > {cache_dir}/ModelFile')
-        elif family and len(family):
-            os.system(f'wget https://modelscope.oss-cn-beijing.aliyuncs.com/llm_template/ollama/{family}.modelfile')
-            command_gen_modelfile = f'cat {family}.modelfile | sed "s/' + '{gguf_file}' + f'/{gguf_file}/" > {cache_dir}/ModelFile'
-            os.system(command_gen_modelfile)
-        else:
-            raise ValueError(f'modelfile 和 model_family至少需要配置一个。用于ollama模型初始化。')
         
         print("download model scuccess!")

--- a/src/model_download/index.py
+++ b/src/model_download/index.py
@@ -7,13 +7,36 @@ def handler(event, context):
     revision = os.getenv('MODEL_VERSION', '')
     cache_dir = os.getenv('MODELSCOPE_CACHE', '')
     sdk_token = os.getenv('MODELSCOPE_TOKEN', '')
+    image_tag = os.getenv('IMAGE_TAG', '')
+    gguf_file = os.getenv('GGUF_FILE', '')
+    modelfile = os.getenv('MODELFILE', '')
+    family = os.getenv('MODEL_FAMILY', '')
+
     # login first.
     HubApi().login(sdk_token)
-    if len(revision) > 0:
-        snapshot_download (model_id =model_id, 
-                           revision =revision,
-                           cache_dir = cache_dir)
-    else:
-         snapshot_download (model_id =model_id, 
+    if image_tag == 'fc-deploy-common-v17.3.3':
+        if len(revision) > 0:
+            snapshot_download (model_id =model_id, 
+                            revision =revision,
                             cache_dir = cache_dir)
-    print("download model scuccess!")
+        else:
+            snapshot_download (model_id =model_id, 
+                                cache_dir = cache_dir)
+        print("download model scuccess!")
+    else:
+        command_download_ollama = f'modelscope download --model=modelscope/ollama-linux --local_dir {cache_dir}/ollama-linux'
+        os.system(command_download_ollama)
+
+        command_download_model = f'modelscope download --model={model_id} --local_dir {cache_dir} ${gguf_file}'
+        os.system(command_download_model)
+
+        if modelfile and len(modelfile):
+            os.system(f'cat {modelfile} > {cache_dir}/ModelFile')
+        elif family and len(family):
+            os.system(f'wget https://modelscope.oss-cn-beijing.aliyuncs.com/llm_template/ollama/{family}.modelfile')
+            command_gen_modelfile = f'cat {family}.modelfile | sed "s/' + '{gguf_file}' + f'/{gguf_file}/" > {cache_dir}/ModelFile'
+            os.system(command_gen_modelfile)
+        else:
+            raise ValueError(f'modelfile 和 model_family至少需要配置一个。用于ollama模型初始化。')
+        
+        print("download model scuccess!")

--- a/src/model_meta_info/index.py
+++ b/src/model_meta_info/index.py
@@ -1,0 +1,8 @@
+import os 
+from modelscope.hub.api import HubApi
+from modelscope.hub.snapshot_download import snapshot_download
+
+def handler(event, context):
+    served_model_name = os.getenv('SERVED_MODEL_NAME', '')
+
+    return {'served_model_name': served_model_name}

--- a/src/s.yaml
+++ b/src/s.yaml
@@ -7,7 +7,7 @@ access: {{ access }}
 
 vars: # 全局变量
   region: {{ region }}
-  version: fc-deploy-common-v17.3.3
+  version: 2024-06-27-8531bd
   service:
     name: {{ serviceName }}
     description: "modelscope deployment"
@@ -63,7 +63,7 @@ services:
         instanceConcurrency: 1
         runtime: custom-container
         customContainerConfig:
-          image: registry.${vars.region}.aliyuncs.com/modelscope-repo/modelscope:${vars.version}
+          image: registry.${vars.region}.aliyuncs.com/modelscope-repo/swingdeploy:${vars.version}
 
       triggers:
         - name: httpTrigger

--- a/src/s.yaml
+++ b/src/s.yaml
@@ -57,7 +57,7 @@ services:
         name: model_meta_func
         description: Meta Api
         codeUri: ./model_meta_info
-        handler: {{ if imageTag == 'fc-deploy-common-v17.3.3' }}not-used{{ else }}index.handler
+        handler: "{{ if imageTag == 'fc-deploy-common-v17.3.3' }}not-used{{ else }}index.handler{{ /if }}"
         timeout: 1800
         caPort: 9000
         instanceType: g1
@@ -88,9 +88,9 @@ services:
         name: model_app_func
         description: Deploy ModelScope applications of model {{ modelId }}
         codeUri: ./model_deploy
-        handler: {{ if imageTag == 'fc-deploy-common-v17.3.3' }}not-used{{ else }}index.handler
+        handler: "{{ if imageTag == 'fc-deploy-common-v17.3.3' }}not-used{{ else }}index.handler{{ /if }}"
         timeout: 1800
-        caPort: {{ if imageTag == 'fc-deploy-common-v17.3.3' }}9000{{ else }}11434
+        caPort: "{{ if imageTag == 'fc-deploy-common-v17.3.3' }}9000{{ else }}11434{{ /if }}"
         instanceType: {{ gpuInstanceType }}
         gpuMemorySize: {{ gpuMemorySize }}
         memorySize: {{ memorySize }}

--- a/src/s.yaml
+++ b/src/s.yaml
@@ -7,7 +7,7 @@ access: {{ access }}
 
 vars: # 全局变量
   region: {{ region }}
-  version: 2024-06-27-8531bd
+  version: {{ imageTag }}
   service:
     name: {{ serviceName }}
     description: "modelscope deployment"
@@ -43,6 +43,10 @@ services:
           MODELSCOPE_CACHE: /mnt/auto
           MODELSCOPE_TOKEN: {{ accessToken }}
           MODELSCOPE_DOMAIN: {{ modelCache }}
+          IMAGE_TAG: {{ imageTag }}
+          GGUF_FILE: {{ ggufFile }}
+          MODELFLE: {{ modelfile }}
+          MODEL_FAMILY: {{ modelFamily }}
 
   model_meta_func:
     component: 'fc'
@@ -52,7 +56,8 @@ services:
       function:
         name: model_meta_func
         description: Meta Api
-        handler: not-used
+        codeUri: ./model_meta_info
+        handler: {{ if imageTag == 'fc-deploy-common-v17.3.3' }}not-used{{ else }}index.handler
         timeout: 1800
         caPort: 9000
         instanceType: g1
@@ -63,8 +68,9 @@ services:
         instanceConcurrency: 1
         runtime: custom-container
         customContainerConfig:
-          image: registry.${vars.region}.aliyuncs.com/modelscope-repo/swingdeploy:${vars.version}
-
+          image: registry.${vars.region}.aliyuncs.com/modelscope-repo/modelscope:${vars.version}
+        environmentVariables:
+          SERVED_MODEL_NAME: {{ servedModelName }}
       triggers:
         - name: httpTrigger
           type: http
@@ -81,9 +87,10 @@ services:
       function:
         name: model_app_func
         description: Deploy ModelScope applications of model {{ modelId }}
-        handler: not-used
+        codeUri: ./model_deploy
+        handler: {{ if imageTag == 'fc-deploy-common-v17.3.3' }}not-used{{ else }}index.handler
         timeout: 1800
-        caPort: 9000
+        caPort: {{ if imageTag == 'fc-deploy-common-v17.3.3' }}9000{{ else }}11434
         instanceType: {{ gpuInstanceType }}
         gpuMemorySize: {{ gpuMemorySize }}
         memorySize: {{ memorySize }}
@@ -101,6 +108,12 @@ services:
           MODELSCOPE_CACHE: /mnt/auto
           MODELSCOPE_TOKEN: {{ accessToken }}
           TASK: {{ task }}
+          IMAGE_TAG: {{ imageTag }}
+          GGUF_FILE: {{ ggufFile }}
+          MODELFLE: {{ modelfile }}
+          MODEL_FAMILY: {{ modelFamily }}
+          MODELSCOPE_DOMAIN: {{ modelCache }}
+          SERVED_MODEL_NAME: {{ servedModelName }}
 
       triggers:
         - name: httpTrigger


### PR DESCRIPTION
未完成，请不要合并

添加ollama部署，同时保留原有的其他模型部署方式：2份完全不同的配置和依赖，以镜像tag做区分。如果不传入镜像tag时，使用原有的模型部署方式。

支持传入镜像tag还有一个预留的好处：后续可方便不同模型、部署方式使用不同镜像。
